### PR TITLE
Change public profile pages to be disabled for unconfirmed users (#17…

### DIFF
--- a/app/controllers/concerns/account_owned_concern.rb
+++ b/app/controllers/concerns/account_owned_concern.rb
@@ -8,6 +8,7 @@ module AccountOwnedConcern
     before_action :set_account, if: :account_required?
     before_action :check_account_approval, if: :account_required?
     before_action :check_account_suspension, if: :account_required?
+    before_action :check_account_confirmation, if: :account_required?
   end
 
   private
@@ -26,6 +27,10 @@ module AccountOwnedConcern
 
   def check_account_approval
     not_found if @account.local? && @account.user_pending?
+  end
+
+  def check_account_confirmation
+    not_found if @account.local? && !@account.user_confirmed?
   end
 
   def check_account_suspension


### PR DESCRIPTION
…385)

Fixes #17382

Note that unconfirmed and unapproved accounts can still be searched for
and their (empty) account retrieved using the REST API.